### PR TITLE
rename `$app/env` to `$app/environment`

### DIFF
--- a/src/lib/ScreenWakeLock.svelte
+++ b/src/lib/ScreenWakeLock.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { browser } from "$app/env";
+  import { browser } from "$app/environment";
 
   import type { WakeLockSentinel } from "src/types";
   import { onDestroy, onMount, createEventDispatcher } from "svelte";


### PR DESCRIPTION
There was a breaking change in SvelteKit (https://github.com/sveltejs/kit/pull/6334) that renamed `@app/env` to `@app/environment`.